### PR TITLE
Remove restriction that SourceMap#apply can only operate on single source file.

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -30,17 +30,20 @@ SourceMap.prototype.copy = function(override) {
  * mapping from the original file.
  *
  * @param {SourceMap|Object} nextSourceMap Source map for a new transformation applied after the current source map.
+ * @param {Number} sourceIdx Index within nextSourceMap.sources of the source file, defaults to undefined which will cause the method to throw an exception when multiple sources exist.
  * @return {SourceMap} A new source map composing both the current and the next.
  */
-SourceMap.prototype.apply = function(nextSourceMap) {
-    // Usually the nextSourceMap maps a single source, which corresponds to
-    // the output of the current source map
+SourceMap.prototype.apply = function(nextSourceMap, sourceIdx) {
     var nextSources = nextSourceMap.sources;
+    if (sourceIdx === undefined && nextSources.length !== 1) {
+      throw new Error('Cannot apply a source map that maps multiple sources');
+    }
+
     var currentMap = new SourceMapConsumer(this);
     var nextMap    = new SourceMapConsumer(nextSourceMap);
 
     var generator = SourceMapGenerator.fromSourceMap(nextMap);
-    generator.applySourceMap(currentMap, nextSources[0]);
+    generator.applySourceMap(currentMap, nextSources[sourceIdx || 0]);
     return fromMapGenerator(generator);
 };
 

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -33,13 +33,9 @@ SourceMap.prototype.copy = function(override) {
  * @return {SourceMap} A new source map composing both the current and the next.
  */
 SourceMap.prototype.apply = function(nextSourceMap) {
-    // We assume the nextSourceMap maps a single source, which
-    // corresponds to the output of the current source map
+    // Usually the nextSourceMap maps a single source, which corresponds to
+    // the output of the current source map
     var nextSources = nextSourceMap.sources;
-    if (nextSources.length !== 1) {
-        throw new Error('Cannot apply a source map that maps multiple sources');
-    }
-
     var currentMap = new SourceMapConsumer(this);
     var nextMap    = new SourceMapConsumer(nextSourceMap);
 


### PR DESCRIPTION
Some transpilers add references to their runtimes in source map entries, usually these are harmless. The source map library will apply them, without this mercator can't be used with source maps provided by transpilers like traceur.
