### PR TITLE
SourceMap#fromSource should preserve columns

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -30,17 +30,20 @@ SourceMap.prototype.copy = function(override) {
  * mapping from the original file.
  *
  * @param {SourceMap|Object} nextSourceMap Source map for a new transformation applied after the current source map.
+ * @param {Number} sourceIdx Index within nextSourceMap.sources of the source file, defaults to undefined which will cause the method to throw an exception when multiple sources exist.
  * @return {SourceMap} A new source map composing both the current and the next.
  */
-SourceMap.prototype.apply = function(nextSourceMap) {
-    // Usually the nextSourceMap maps a single source, which corresponds to
-    // the output of the current source map
+SourceMap.prototype.apply = function(nextSourceMap, sourceIdx) {
     var nextSources = nextSourceMap.sources;
+    if (sourceIdx === undefined && nextSources.length !== 1) {
+      throw new Error('Cannot apply a source map that maps multiple sources');
+    }
+
     var currentMap = new SourceMapConsumer(this);
     var nextMap    = new SourceMapConsumer(nextSourceMap);
 
     var generator = SourceMapGenerator.fromSourceMap(nextMap);
-    generator.applySourceMap(currentMap, nextSources[0]);
+    generator.applySourceMap(currentMap, nextSources[sourceIdx || 0]);
     return fromMapGenerator(generator);
 };
 

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var esprima = require('esprima');
 
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var SourceMapConsumer  = require('source-map').SourceMapConsumer;
@@ -231,10 +232,12 @@ function forSource(data, sourcePath) {
 
     generator.setSourceContent(sourcePath, data);
 
-    data.split('\n').forEach(function(l, i) {
+    var tokens = esprima.tokenize(data, { loc: true });
+    tokens.forEach(function(token) {
+        var loc = token.loc.start;
         generator.addMapping({
-            generated: { line: i + 1, column: null },
-            original:  { line: i + 1, column: null },
+            generated: loc,
+            original:  loc,
             source: sourcePath
         });
     });

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -33,13 +33,9 @@ SourceMap.prototype.copy = function(override) {
  * @return {SourceMap} A new source map composing both the current and the next.
  */
 SourceMap.prototype.apply = function(nextSourceMap) {
-    // We assume the nextSourceMap maps a single source, which
-    // corresponds to the output of the current source map
+    // Usually the nextSourceMap maps a single source, which corresponds to
+    // the output of the current source map
     var nextSources = nextSourceMap.sources;
-    if (nextSources.length !== 1) {
-        throw new Error('Cannot apply a source map that maps multiple sources');
-    }
-
     var currentMap = new SourceMapConsumer(this);
     var nextMap    = new SourceMapConsumer(nextSourceMap);
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "esprima": "^1.2.2",
+    "esprima": "~1.2.2",
     "source-map": "~0.1.31"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lib": "./lib"
   },
   "dependencies": {
+    "esprima": "^1.2.2",
     "source-map": "~0.1.31"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -71,17 +71,8 @@ describe('SourceMap', function() {
 
         it('should return a source map mapping the file onto itself', function() {
             var map = SourceMap.forSource(source, path);
-            var consumer = new SourceMapConsumer(map);
-
-            var numLines = numLines = source.split('\n').length;
-            for (var line = 1; line <= numLines; line++) {
-                consumer.originalPositionFor({line: line, column: 0}).should.deep.equal({
-                    source: path,
-                    line: line,
-                    column: 0,
-                    name: null
-                });
-            }
+            // Should map according to javascript tokens.
+            map.mappings.should.equal('AAAA,IAAI,EAAE,EAAE,CAAC;AACT,IAAI,EAAE,EAAE,CAAC;;;;AAIT,SAAS,GAAG,CAAC,CAAC,EAAE;IACZ,OAAO,EAAE,EAAE,CAAC;AAChB;;AAEA,IAAI,EAAE,EAAE,GAAG,CAAC,CAAC,CAAC');
         });
     });
 


### PR DESCRIPTION
This fixes plumber losing column information during certain operations.

Fixes https://github.com/plumberjs/mercator/issues/5
